### PR TITLE
Fix immutable remove

### DIFF
--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/RemoveVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/alter/RemoveVisitor.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -215,6 +216,11 @@ public class RemoveVisitor implements ICatalogVisitor<Boolean, RemoveVisitor.Con
     throw new UnsupportedOperationException("not needed");
   }
 
+  @NonNull
+  private static <T> List<T> modifiableListOrEmpty(@Nullable List<T> list) {
+    return list == null ? CollectionUtil.emptyList() : list;
+  }
+
   @Override
   public Boolean visitControl(Control control, Context context) {
     assert context != null;
@@ -222,27 +228,27 @@ public class RemoveVisitor implements ICatalogVisitor<Boolean, RemoveVisitor.Con
     // visit params
     boolean retval = handle(
         TargetType.PARAM,
-        () -> CollectionUtil.listOrEmpty(control.getParams()),
+        () -> modifiableListOrEmpty(control.getParams()),
         child -> visitParameter(ObjectUtils.notNull(child), context),
         context);
 
     // visit props
     retval = retval || handle(
         TargetType.PROP,
-        () -> CollectionUtil.listOrEmpty(control.getProps()),
+        () -> modifiableListOrEmpty(control.getProps()),
         null,
         context);
 
     // visit links
     retval = retval || handle(
         TargetType.LINK,
-        () -> CollectionUtil.listOrEmpty(control.getLinks()),
+        () -> modifiableListOrEmpty(control.getLinks()),
         null,
         context);
 
     return retval || handle(
         TargetType.PART,
-        () -> CollectionUtil.listOrEmpty(control.getParts()),
+        () -> modifiableListOrEmpty(control.getParts()),
         child -> visitPart(child, context),
         context);
   }
@@ -254,13 +260,13 @@ public class RemoveVisitor implements ICatalogVisitor<Boolean, RemoveVisitor.Con
     // visit props
     boolean retval = handle(
         TargetType.PROP,
-        () -> CollectionUtil.listOrEmpty(parameter.getProps()),
+        () -> modifiableListOrEmpty(parameter.getProps()),
         null,
         context);
 
     return retval || handle(
         TargetType.LINK,
-        () -> CollectionUtil.listOrEmpty(parameter.getLinks()),
+        () -> modifiableListOrEmpty(parameter.getLinks()),
         null,
         context);
   }
@@ -280,20 +286,20 @@ public class RemoveVisitor implements ICatalogVisitor<Boolean, RemoveVisitor.Con
     // visit props
     boolean retval = handle(
         TargetType.PROP,
-        () -> CollectionUtil.listOrEmpty(part.getProps()),
+        () -> modifiableListOrEmpty(part.getProps()),
         null,
         context);
 
     // visit links
     retval = retval || handle(
         TargetType.LINK,
-        () -> CollectionUtil.listOrEmpty(part.getLinks()),
+        () -> modifiableListOrEmpty(part.getLinks()),
         null,
         context);
 
     return retval || handle(
         TargetType.PART,
-        () -> CollectionUtil.listOrEmpty(part.getParts()),
+        () -> modifiableListOrEmpty(part.getParts()),
         child -> visitPart(child, context),
         context);
   }


### PR DESCRIPTION
# Committer Notes

Addressed a bug caused when an immutable collection is returned and items are attempted to be removed from them. Adjusted the method of getting the collection to ensure a mutable collection is returned allowing items to be removed.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/liboscal-java/blob/main/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/liboscal-java/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
