### PR TITLE
Bump metaschema-java version from 1.0.2 to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<dependency.metaschema-framework.version>1.0.2</dependency.metaschema-framework.version>
+		<dependency.metaschema-framework.version>1.1.0</dependency.metaschema-framework.version>
 
 		<dependency.auto-service.version>1.1.1</dependency.auto-service.version>
 		<dependency.commons-lang3.version>3.17.0</dependency.commons-lang3.version>


### PR DESCRIPTION
# Committer Notes

Update metaschema-java dependency from [1.0.2](https://github.com/metaschema-framework/metaschema-java/releases/tag/v1.0.2) to [1.1.0](https://github.com/metaschema-framework/metaschema-java/releases/tag/v1.1.0).

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/liboscal-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/liboscal-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
