### PR TITLE
Address duplicate controls at catalog level in profile resolution

### DIFF
--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/DefaultResult.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/DefaultResult.java
@@ -81,6 +81,7 @@ public class DefaultResult implements IResult {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.atDebug().log("promoting control '{}'", control.getId());
     }
+    // promote
     promotedControls.get().add(control);
   }
 
@@ -90,6 +91,7 @@ public class DefaultResult implements IResult {
     getPromotedParameters().forEach(param -> parent.addParam(ObjectUtils.notNull(param)));
     getPromotedControls().forEach(control -> {
       assert control != null;
+      // add promoted control
       parent.addControl(control);
       control.setParentControl(null);
     });

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/FilterNonSelectedVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/FilterNonSelectedVisitor.java
@@ -269,7 +269,6 @@ public class FilterNonSelectedVisitor
     private final IIndexer indexer;
 
     private Context(@NonNull IIndexer indexer) {
-      super();
       this.indexer = indexer;
     }
 

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/Import.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/Import.java
@@ -32,6 +32,7 @@ import gov.nist.secauto.oscal.lib.profile.resolver.policy.ReferenceCountingVisit
 import gov.nist.secauto.oscal.lib.profile.resolver.support.BasicIndexer;
 import gov.nist.secauto.oscal.lib.profile.resolver.support.IEntityItem;
 import gov.nist.secauto.oscal.lib.profile.resolver.support.IIndexer;
+import gov.nist.secauto.oscal.lib.profile.resolver.support.IIndexer.SelectionStatus;
 
 import java.net.URI;
 import java.util.LinkedList;
@@ -97,6 +98,9 @@ public class Import {
     // determine which controls and groups to keep
     IControlFilter filter = newControlFilter();
     IIndexer indexer = newIndexer();
+    // the catalog is always selected. This ensures that controls defined at the
+    // catalog level are kept and not duplicated
+    indexer.setSelectionStatus(importedCatalogDocument.getRootAssemblyNodeItem(), SelectionStatus.SELECTED);
     IControlSelectionState state = new ControlSelectionState(indexer, filter);
 
     try {

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionTests.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolutionTests.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.oscal.lib.profile.resolver;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -234,5 +235,15 @@ class ProfileResolutionTests {
     Catalog resolvedCatalog = resolveProfile(url);
 
     assertNotNull(resolvedCatalog);
+  }
+
+  @Test
+  void testMultipleImports() throws IOException, ProfileResolutionException, URISyntaxException {
+    File file = new File("src/test/resources/content/oscal-cli-60-profile.json");
+    Catalog resolvedCatalog = resolveProfile(file);
+    assertAll(
+        () -> assertNotNull(resolvedCatalog),
+        () -> assertEquals(1,
+            resolvedCatalog.getControls().stream().filter(control -> "sc-19".equals(control.getId())).count()));
   }
 }

--- a/src/test/resources/content/oscal-cli-60-catalog.json
+++ b/src/test/resources/content/oscal-cli-60-catalog.json
@@ -1,0 +1,108 @@
+{
+  "catalog": {
+    "uuid": "75505e0e-a09d-484a-a4a7-405dab6de2c9",
+    "controls": [
+      {
+        "id": "ac-17.400",
+        "parts": [
+          {
+            "prose": "Access to privileged account remotely is only done from dedicated management consoles.",
+            "name": "statement",
+            "id": "ac-17.400_smt"
+          },
+          {
+            "prose": "Remote access to systems represents a significant potential vulnerability that can be exploited by adversaries. As such, restricting the execution of privileged commands and access to security-relevant information via remote access reduces the exposure of the organization and the susceptibility to threats by adversaries to the remote access capability.",
+            "name": "guidance",
+            "id": "ac-17.400_gdn"
+          }
+        ],
+        "props": [
+          {
+            "name": "label",
+            "class": "zero-padded",
+            "value": "AC-17(400)"
+          },
+          {
+            "name": "label",
+            "value": "AC-17(400)"
+          },
+          {
+            "name": "sort-id",
+            "value": "ac-17.400"
+          }
+        ],
+        "title": "Privileged Accounts Remote Access"
+      },
+      {
+        "id": "sc-19",
+        "parts": [
+          {
+            "parts": [
+              {
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "a."
+                  }
+                ],
+                "prose": "Establishes usage restrictions and implementation guidance for Voice over Internet Protocol (VoIP) technologies based on the potential to cause damage to the information system if used maliciously; and",
+                "name": "item",
+                "id": "sc-19_smt.a"
+              },
+              {
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "b."
+                  }
+                ],
+                "prose": "Authorizes, monitors, and controls the use of VoIP within the information system.",
+                "name": "item",
+                "id": "sc-19_smt.b"
+              }
+            ],
+            "prose": "The organization:",
+            "name": "statement",
+            "id": "sc-19_smt"
+          },
+          {
+            "name": "guidance",
+            "links": [
+              {
+                "href": "#cm-6",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-7",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-15",
+                "rel": "related"
+              }
+            ],
+            "id": "sc-19_gdn"
+          }
+        ],
+        "props": [
+          {
+            "name": "label",
+            "value": "SC-19"
+          },
+          {
+            "name": "sort-id",
+            "value": "sc-19"
+          }
+        ],
+        "title": "Voice Over Internet Protocol"
+      }
+    ],
+    "metadata": {
+      "oscal-version": "1.1.2",
+      "last-modified": "2024-09-16T23:16:00Z",
+      "title": "OSCAL CLI #60 Control Catalog",
+      "version": "1.0.0"
+    },
+    "back-matter": {}
+  }
+}

--- a/src/test/resources/content/oscal-cli-60-profile.json
+++ b/src/test/resources/content/oscal-cli-60-profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "back-matter": {},
+    "uuid": "e057c6c7-c436-44b4-9d75-c503eef04f37",
+    "metadata": {
+      "version": "1.0.0",
+      "oscal-version": "1.1.2",
+      "last-modified": "2024-10-01T23:16:00Z",
+      "title": "Modifications to NIST 800-53"
+    },
+    "imports": [
+      {
+        "href": "https://raw.githubusercontent.com/usnistgov/oscal-content/941c978d14c57379fbf6f7fb388f675067d5bff7/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json",
+        "include-controls": [
+          {
+            "with-ids": ["ac-1"]
+          }
+        ]
+      },
+      {
+        "href": "oscal-cli-60-catalog.json",
+        "include-all": {}
+      }
+    ],
+    "merge": {
+      "as-is": true
+    }
+  }
+}


### PR DESCRIPTION
# Committer Notes

Ensure that controls defined at the catalog level are not duplicated. This fixes a bug caused during the import handling phase of profile resolution, which was "promoting" controls defined at the catalog level, causing a second copy of the control to be added. This was fixed by making controls at the catalog level always eligible for selection.

Resolves metaschema-framework/oscal-cli#60

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/liboscal-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/liboscal-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/liboscal-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
