### PR TITLE
Improve profile resolution exceptions

### DIFF
--- a/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/ResolveProfile.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/ResolveProfile.java
@@ -141,7 +141,11 @@ public final class ResolveProfile {
       try {
         retval = resolver.resolve(profile);
       } catch (IOException | ProfileResolutionException ex) {
-        throw new MetapathException(String.format("Fun: Unable to resolve profile '%s'", profile.getBaseUri()), ex);
+        throw new MetapathException(
+            String.format("Unable to resolve profile '%s'. %s",
+                profile.getBaseUri(),
+                ex.getLocalizedMessage()),
+            ex);
       }
     }
     return retval;

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolver.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/ProfileResolver.java
@@ -439,12 +439,17 @@ public class ProfileResolver {
       URI uri = rlink == null ? null : rlink.getHref();
 
       if (uri == null) {
-        throw new IOException(String.format("unable to determine URI for resource '%s'", resource.getUuid()));
+        throw new IOException(
+            String.format("Unable to determine URI for resource '%s'.", resource.getUuid()));
       }
 
       uri = baseUri.resolve(uri);
       assert uri != null;
-      retval = loader.loadAsNodeItem(uri);
+      try {
+        retval = loader.loadAsNodeItem(uri);
+      } catch (IOException ex) {
+        throw new IOException(String.format("Unable to load resource '%s'.", uri), ex);
+      }
     }
     return retval;
   }


### PR DESCRIPTION
…nces during profile resolution. The underlying cause will now be reported.

# Committer Notes

Improved profile exception handling involving throw IOException instances during profile resolution. The underlying cause will now be reported.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/liboscal-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/liboscal-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/liboscal-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
