### PR TITLE
Support generation of relative links during profile resolution

### DIFF
--- a/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/ResolveProfile.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/metapath/function/library/ResolveProfile.java
@@ -137,7 +137,8 @@ public final class ResolveProfile {
       retval = profile;
     } else {
       // this is a profile
-      ProfileResolver resolver = new ProfileResolver(dynamicContext);
+      ProfileResolver resolver
+          = new ProfileResolver(dynamicContext, (uri, source) -> profile.getDocumentUri().resolve(uri));
       try {
         retval = resolver.resolve(profile);
       } catch (IOException | ProfileResolutionException ex) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/merge/FlatteningStructuringVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/merge/FlatteningStructuringVisitor.java
@@ -17,6 +17,7 @@ import gov.nist.secauto.oscal.lib.model.Metadata.Location;
 import gov.nist.secauto.oscal.lib.model.Metadata.Party;
 import gov.nist.secauto.oscal.lib.model.Metadata.Role;
 import gov.nist.secauto.oscal.lib.model.Parameter;
+import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolver;
 import gov.nist.secauto.oscal.lib.profile.resolver.policy.ReferenceCountingVisitor;
 import gov.nist.secauto.oscal.lib.profile.resolver.selection.DefaultResult;
 import gov.nist.secauto.oscal.lib.profile.resolver.selection.FilterNonSelectedVisitor;
@@ -26,7 +27,6 @@ import gov.nist.secauto.oscal.lib.profile.resolver.support.IEntityItem.ItemType;
 import gov.nist.secauto.oscal.lib.profile.resolver.support.IIndexer;
 import gov.nist.secauto.oscal.lib.profile.resolver.support.IIndexer.SelectionStatus;
 
-import java.net.URI;
 import java.util.EnumSet;
 import java.util.UUID;
 
@@ -35,17 +35,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class FlatteningStructuringVisitor
     extends AbstractCatalogEntityVisitor<IIndexer, Void> {
-  private static final FlatteningStructuringVisitor SINGLETON = new FlatteningStructuringVisitor();
+  @NonNull
+  private final ProfileResolver.UriResolver uriResolver;
 
-  @SuppressFBWarnings(value = "SING_SINGLETON_GETTER_NOT_SYNCHRONIZED", justification = "class initialization")
-  public static FlatteningStructuringVisitor instance() {
-    return SINGLETON;
-  }
-
-  @SuppressFBWarnings(value = "SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR",
-      justification = "public constructor allows for extension usecases")
-  public FlatteningStructuringVisitor() {
+  public FlatteningStructuringVisitor(@NonNull ProfileResolver.UriResolver uriResolver) {
     super(ObjectUtils.notNull(EnumSet.of(ItemType.GROUP, ItemType.CONTROL)));
+    this.uriResolver = uriResolver;
   }
 
   @Override
@@ -75,8 +70,7 @@ public class FlatteningStructuringVisitor
     }
 
     // process references, looking for orphaned links to groups
-    URI catalogUri = ObjectUtils.requireNonNull(catalogItem.getDocumentUri());
-    ReferenceCountingVisitor.instance().visitCatalog(catalogItem, index, catalogUri);
+    ReferenceCountingVisitor.instance().visitCatalog(catalogItem, index, uriResolver);
 
     FlatteningFilterNonSelectedVisitor.instance().visitCatalog(catalogItem, index);
     return null;

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AnchorReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/AnchorReferencePolicy.java
@@ -12,6 +12,7 @@ import com.vladsch.flexmark.util.sequence.CharSubSequence;
 import gov.nist.secauto.metaschema.core.metapath.format.IPathFormatter;
 import gov.nist.secauto.metaschema.core.metapath.item.node.IModelNodeItem;
 import gov.nist.secauto.metaschema.core.util.CustomCollectors;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.oscal.lib.profile.resolver.support.IEntityItem;
 
 import org.apache.logging.log4j.LogManager;
@@ -57,10 +58,10 @@ public class AnchorReferencePolicy
       @NonNull InlineLinkNode link,
       @NonNull IEntityItem item,
       @NonNull ReferenceCountingVisitor.Context visitorContext) {
-    URI linkHref = URI.create(link.getUrl().toString());
+    URI linkHref = ObjectUtils.notNull(URI.create(link.getUrl().toString()));
     URI sourceUri = item.getSource();
 
-    URI resolved = sourceUri.resolve(linkHref);
+    URI resolved = visitorContext.getUriResolver().resolve(linkHref, sourceUri);
     if (LOGGER.isTraceEnabled()) {
       LOGGER.atTrace().log("At path '{}', remapping orphaned URI '{}' to '{}'",
           contextItem.toPath(IPathFormatter.METAPATH_PATH_FORMATER),

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/LinkReferencePolicy.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/LinkReferencePolicy.java
@@ -59,7 +59,7 @@ public class LinkReferencePolicy
     URI linkHref = link.getHref();
     URI sourceUri = item.getSource();
 
-    URI resolved = sourceUri.resolve(linkHref);
+    URI resolved = visitorContext.getUriResolver().resolve(linkHref, sourceUri);
     if (LOGGER.isTraceEnabled()) {
       LOGGER.atTrace().log("At path '{}', remapping orphaned URI '{}' to '{}'",
           contextItem.toPath(IPathFormatter.METAPATH_PATH_FORMATER),

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitor.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitor.java
@@ -30,6 +30,7 @@ import gov.nist.secauto.oscal.lib.model.Link;
 import gov.nist.secauto.oscal.lib.model.Property;
 import gov.nist.secauto.oscal.lib.model.metadata.AbstractProperty;
 import gov.nist.secauto.oscal.lib.model.metadata.IProperty;
+import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolver.UriResolver;
 import gov.nist.secauto.oscal.lib.profile.resolver.support.AbstractCatalogEntityVisitor;
 import gov.nist.secauto.oscal.lib.profile.resolver.support.IEntityItem;
 import gov.nist.secauto.oscal.lib.profile.resolver.support.IIndexer;
@@ -37,7 +38,6 @@ import gov.nist.secauto.oscal.lib.profile.resolver.support.IIndexer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.net.URI;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -165,8 +165,11 @@ public final class ReferenceCountingVisitor
   // }
   // }
 
-  public void visitCatalog(@NonNull IDocumentNodeItem catalogItem, @NonNull IIndexer indexer, @NonNull URI baseUri) {
-    Context context = new Context(indexer, baseUri);
+  public void visitCatalog(
+      @NonNull IDocumentNodeItem catalogItem,
+      @NonNull IIndexer indexer,
+      @NonNull UriResolver resolver) {
+    Context context = new Context(indexer, resolver);
     visitCatalog(catalogItem, context);
 
     IIndexer index = context.getIndexer();
@@ -568,13 +571,13 @@ public final class ReferenceCountingVisitor
     @NonNull
     private final IIndexer indexer;
     @NonNull
-    private final URI source;
+    private final UriResolver resolver;
     @NonNull
     private final Set<IEntityItem> resolvedEntities = new HashSet<>();
 
-    private Context(@NonNull IIndexer indexer, @NonNull URI source) {
+    private Context(@NonNull IIndexer indexer, @NonNull UriResolver resolver) {
       this.indexer = indexer;
-      this.source = source;
+      this.resolver = resolver;
     }
 
     @NonNull
@@ -583,15 +586,14 @@ public final class ReferenceCountingVisitor
       return indexer;
     }
 
+    @NonNull
+    public UriResolver getUriResolver() {
+      return resolver;
+    }
+
     @Nullable
     public IEntityItem getEntity(@NonNull IEntityItem.ItemType itemType, @NonNull String identifier) {
       return getIndexer().getEntity(itemType, identifier);
-    }
-
-    @SuppressWarnings("unused")
-    @NonNull
-    private URI getSource() {
-      return source;
     }
 
     public void markResolved(@NonNull IEntityItem entity) {

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/Import.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/Import.java
@@ -27,6 +27,7 @@ import gov.nist.secauto.oscal.lib.model.Parameter;
 import gov.nist.secauto.oscal.lib.model.ProfileImport;
 import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolutionEvaluationException;
 import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolutionException;
+import gov.nist.secauto.oscal.lib.profile.resolver.ProfileResolver.UriResolver;
 import gov.nist.secauto.oscal.lib.profile.resolver.policy.ReferenceCountingVisitor;
 import gov.nist.secauto.oscal.lib.profile.resolver.support.BasicIndexer;
 import gov.nist.secauto.oscal.lib.profile.resolver.support.IEntityItem;
@@ -85,7 +86,10 @@ public class Import {
   }
 
   @NonNull
-  public IIndexer resolve(@NonNull IDocumentNodeItem importedCatalogDocument, @NonNull Catalog resolvedCatalog)
+  public IIndexer resolve(
+      @NonNull IDocumentNodeItem importedCatalogDocument,
+      @NonNull Catalog resolvedCatalog,
+      @NonNull UriResolver uriResolver)
       throws ProfileResolutionException {
     ProfileImport profileImport = getProfileImport();
     URI uri = ObjectUtils.requireNonNull(profileImport.getHref(), "profile import href is null");
@@ -99,7 +103,7 @@ public class Import {
       ControlSelectionVisitor.instance().visitCatalog(importedCatalogDocument, state);
 
       // process references
-      ReferenceCountingVisitor.instance().visitCatalog(importedCatalogDocument, indexer, uri);
+      ReferenceCountingVisitor.instance().visitCatalog(importedCatalogDocument, indexer, uriResolver);
 
       // filter based on selections
       FilterNonSelectedVisitor.instance().visitCatalog(importedCatalogDocument, indexer);

--- a/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/IEntityItem.java
+++ b/src/main/java/gov/nist/secauto/oscal/lib/profile/resolver/support/IEntityItem.java
@@ -78,6 +78,7 @@ public interface IEntityItem {
   @NonNull
   ItemType getItemType();
 
+  @NonNull
   URI getSource();
 
   int getReferenceCount();

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitorTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/policy/ReferenceCountingVisitorTest.java
@@ -47,7 +47,10 @@ class ReferenceCountingVisitorTest {
 
     // setup reference counting
     ReferenceCountingVisitor.instance()
-        .visitCatalog(importedCatalogDocumentItem, indexer, importedCatalogDocumentItem.getBaseUri());
+        .visitCatalog(
+            importedCatalogDocumentItem,
+            indexer,
+            (uri, src) -> importedCatalogDocumentItem.getBaseUri().resolve(uri));
 
     IIndexer.logIndex(indexer, Level.DEBUG);
 

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/FilterNonSelectedVisitorTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/FilterNonSelectedVisitorTest.java
@@ -47,8 +47,10 @@ class FilterNonSelectedVisitorTest {
     ControlSelectionVisitor.instance().visitCatalog(importedCatalogDocumentItem, state);
 
     // setup reference counting
-    ReferenceCountingVisitor.instance().visitCatalog(importedCatalogDocumentItem, indexer,
-        importedCatalogDocumentItem.getBaseUri());
+    ReferenceCountingVisitor.instance().visitCatalog(
+        importedCatalogDocumentItem,
+        indexer,
+        (uri, src) -> importedCatalogDocumentItem.getBaseUri().resolve(uri));
 
     FilterNonSelectedVisitor.instance().visitCatalog(importedCatalogDocumentItem, indexer);
 

--- a/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/ImportTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/profile/resolver/selection/ImportTest.java
@@ -88,7 +88,10 @@ class ImportTest {
               .map(item -> (IAssemblyNodeItem) item))) {
 
         Import catalogImport = new Import(profileRootItem, importItem);
-        catalogImport.resolve(importedCatalogDocumentItem, resolvedCatalog);
+        catalogImport.resolve(
+            importedCatalogDocumentItem,
+            resolvedCatalog,
+            (uri, src) -> importedCatalogDocumentItem.getBaseUri().resolve(uri));
       }
 
     }


### PR DESCRIPTION
# Committer Notes

Added support for relative resource resolution for links generated by the profile resolver.

Supports metaschema-framework/oscal-cli#84

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/liboscal-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/liboscal-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/liboscal-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
