### PR TITLE
Add concurrency and nightly build support to GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
     - develop
     - feature/**
   merge_group:
+  schedule:
+    # Nightly build at 3:00 AM UTC (after metaschema-java)
+    - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
       linkcheck_fail_on_error:
@@ -24,6 +27,9 @@ on:
         default: false
         type: boolean
 name: Build and Test
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   INPUT_FAIL_ON_ERROR: ${{ github.event.inputs.linkcheck_fail_on_error || 'true' }}
   INPUT_ISSUE_ON_ERROR: ${{ github.event.inputs.linkcheck_create_issue || 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     - "v*"
   workflow_dispatch:
 name: Deploy Tagged Release
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   MAVEN_VERSION: 3.9.8
   JAVA_DISTRO: 'temurin'


### PR DESCRIPTION
## Summary

- Add concurrency configuration to `build.yml` and `release.yml` workflows
- Cancel in-progress workflow runs when new commits are pushed to the same branch/PR
- Add scheduled nightly build at 3:00 AM UTC (after metaschema-java)

## Changes

**Concurrency (build.yml and release.yml):**
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

**Nightly schedule (build.yml):**
```yaml
schedule:
  # Nightly build at 3:00 AM UTC (after metaschema-java)
  - cron: '0 3 * * *'
```

## Nightly Build Schedule

| Repository | Schedule (UTC) |
|------------|---------------|
| metaschema-java | 2:00 AM |
| liboscal-java | 3:00 AM |
| oscal-cli | 4:00 AM |

## Related

- Addresses #110

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test concurrency by pushing multiple commits in quick succession
- [ ] Confirm older runs are cancelled when new runs start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and release workflow concurrency to prevent overlapping runs and cancel in-progress executions when newer runs start.
  * Added a nightly scheduled execution (03:00 UTC) to ensure regular automated releases and checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->