### PR TITLE
Update metaschema-java to v3.0.0.M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 		<project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<dependency.metaschema-framework.version>3.0.0.M1-SNAPSHOT</dependency.metaschema-framework.version>
+		<dependency.metaschema-framework.version>3.0.0.M1</dependency.metaschema-framework.version>
 
 		<dependency.commons-lang3.version>3.20.0</dependency.commons-lang3.version>
 		<dependency.jmock-junit5.version>2.13.1</dependency.jmock-junit5.version>


### PR DESCRIPTION
## Summary

Updates metaschema-java dependency from `3.0.0.M1-SNAPSHOT` to the released `3.0.0.M1` version.

See [metaschema-java v3.0.0.M1 release notes](https://github.com/metaschema-framework/metaschema-java/releases/tag/v3.0.0.M1) for details on breaking changes and new features.

### Breaking Changes to Note

- **XMLBeans removed from core module**: If liboscal-java was using `ModuleLoader` or `XmlConstraintLoader` from core, these should be replaced with `BindingModuleLoader` and `BindingConstraintLoader` from databind.
- **Metapath exception hierarchy refactored**: Code catching specific Metapath exceptions may need updates.

## Test plan

- [ ] Build passes with `mvn install`
- [ ] Tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated framework dependency to the latest milestone release version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->