### PR TITLE
fix: make ComponentDefinition and MappingCollection implement IOscalInstance

### DIFF
--- a/src/main/metaschema-bindings/oscal-metaschema-bindings.xml
+++ b/src/main/metaschema-bindings/oscal-metaschema-bindings.xml
@@ -113,6 +113,11 @@
 	</metaschema-binding>
 	<metaschema-binding
 		href="../../../oscal/src/metaschema/oscal_component_metaschema.xml">
+		<define-assembly-binding name="component-definition">
+			<java>
+				<extend-base-class>gov.nist.secauto.oscal.lib.model.AbstractOscalInstance</extend-base-class>
+			</java>
+		</define-assembly-binding>
 		<define-assembly-binding name="component">
 			<java>
 				<extend-base-class>gov.nist.secauto.oscal.lib.model.AbstractOscalInstance</extend-base-class>
@@ -164,6 +169,14 @@
 	<metaschema-binding
 		href="../../../oscal/src/metaschema/oscal_assessment-results_metaschema.xml">
 		<define-assembly-binding name="assessment-results">
+			<java>
+				<extend-base-class>gov.nist.secauto.oscal.lib.model.AbstractOscalInstance</extend-base-class>
+			</java>
+		</define-assembly-binding>
+	</metaschema-binding>
+	<metaschema-binding
+		href="../../../oscal/src/metaschema/oscal_mapping_metaschema.xml">
+		<define-assembly-binding name="mapping-collection">
 			<java>
 				<extend-base-class>gov.nist.secauto.oscal.lib.model.AbstractOscalInstance</extend-base-class>
 			</java>

--- a/src/test/java/gov/nist/secauto/oscal/lib/validation/ComponentDefinitionImportTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/validation/ComponentDefinitionImportTest.java
@@ -1,0 +1,142 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.oscal.lib.validation;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import gov.nist.secauto.metaschema.core.model.validation.IValidationResult;
+import gov.nist.secauto.oscal.lib.OscalBindingContext;
+import gov.nist.secauto.oscal.lib.model.ComponentDefinition;
+import gov.nist.secauto.oscal.lib.model.IOscalInstance;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Test case to reproduce oscal-cli issue #192: ClassCastException when
+ * validating ComponentDefinition with import-component-definitions.
+ *
+ * @see <a href=
+ *      "https://github.com/metaschema-framework/oscal-cli/issues/192">Issue
+ *      #192</a>
+ */
+class ComponentDefinitionImportTest {
+  private static final Logger LOGGER = LogManager.getLogger(ComponentDefinitionImportTest.class);
+
+  /**
+   * Demonstrates that ComponentDefinition does NOT implement IOscalInstance,
+   * which is the root cause of the ClassCastException in ResolveReference.
+   */
+  @Test
+  void testComponentDefinitionDoesNotImplementIOscalInstance() throws IOException {
+    OscalBindingContext bindingContext = OscalBindingContext.newInstance();
+
+    // Load the base component definition
+    Path basePath = Paths.get("src/test/resources/content/issue-192/base-component-definition.json");
+    ComponentDefinition componentDef = bindingContext.loadComponentDefinition(basePath);
+
+    // Verify that ComponentDefinition does NOT implement IOscalInstance
+    // This is the root cause of the bug - the cast in
+    // ResolveReference.resolveReference() line 152
+    boolean implementsIOscalInstance = componentDef instanceof IOscalInstance;
+
+    LOGGER.info("ComponentDefinition implements IOscalInstance: {}", implementsIOscalInstance);
+
+    // This assertion documents the bug: ComponentDefinition SHOULD implement
+    // IOscalInstance
+    // but currently does NOT
+    if (implementsIOscalInstance) {
+      LOGGER.info("Bug appears to be fixed - ComponentDefinition now implements IOscalInstance");
+    } else {
+      LOGGER.warn("Bug confirmed: ComponentDefinition does NOT implement IOscalInstance");
+      LOGGER.warn("This causes ClassCastException in ResolveReference.resolveReference() at line 152");
+    }
+
+    // Asserting false to document the current broken state
+    // When the bug is fixed, this test should be updated to assertTrue
+    assertTrue(!implementsIOscalInstance,
+        "This test documents the bug: ComponentDefinition should implement IOscalInstance but doesn't");
+  }
+
+  /**
+   * Reproduces the ClassCastException from oscal-cli issue #192.
+   *
+   * When validating a ComponentDefinition with import-component-definitions that
+   * uses a fragment reference (href="#uuid"), the constraint evaluation calls
+   * resolve-reference() which attempts to cast the root ComponentDefinition to
+   * IOscalInstance, causing:
+   *
+   * ClassCastException: class
+   * gov.nist.secauto.oscal.lib.model.ComponentDefinition cannot be cast to class
+   * gov.nist.secauto.oscal.lib.model.IOscalInstance
+   */
+  @Test
+  void testValidateComponentDefinitionWithImportCausesClassCastException() {
+    OscalBindingContext bindingContext = OscalBindingContext.newInstance();
+
+    Path componentDefPath = Paths.get("src/test/resources/content/issue-192/component-definition-with-import.json");
+
+    try {
+      // This validation should trigger the constraint that uses resolve-reference()
+      // The constraint is defined in ComponentDefinition's @ValueConstraints
+      // annotation:
+      // "import-component-definition !
+      // recurse-depth('doc(resolve-uri(Q{...}resolve-reference(@href)))/component-definition')"
+      IValidationResult validationResult = bindingContext.validateWithConstraints(
+          componentDefPath.toUri(),
+          null);
+
+      // If we get here without exception, check if validation passed or had expected
+      // findings
+      if (validationResult.isPassing()) {
+        LOGGER.info("Validation passed - bug may be fixed or constraint not triggered");
+      } else {
+        LOGGER.info("Validation completed with findings (no ClassCastException)");
+      }
+
+    } catch (ClassCastException e) {
+      // This is the expected behavior when the bug is present
+      LOGGER.error("Bug reproduced: ClassCastException during validation", e);
+
+      // Verify it's the specific cast error from ResolveReference
+      assertTrue(e.getMessage().contains("ComponentDefinition")
+          && e.getMessage().contains("IOscalInstance"),
+          "Expected ClassCastException from ComponentDefinition to IOscalInstance cast");
+
+      // Fail the test to indicate the bug exists
+      fail("Issue #192 reproduced: " + e.getMessage());
+
+    } catch (Exception e) {
+      // Log any other exception for debugging
+      LOGGER.error("Unexpected exception during validation", e);
+
+      // Check if the root cause is the ClassCastException
+      Throwable cause = e;
+      while (cause != null) {
+        if (cause instanceof ClassCastException) {
+          ClassCastException cce = (ClassCastException) cause;
+          if (cce.getMessage() != null
+              && cce.getMessage().contains("ComponentDefinition")
+              && cce.getMessage().contains("IOscalInstance")) {
+            LOGGER.error("Bug reproduced (wrapped): ClassCastException found in cause chain", cce);
+            fail("Issue #192 reproduced (wrapped exception): " + cce.getMessage());
+          }
+        }
+        cause = cause.getCause();
+      }
+
+      // Re-throw if it's not the expected ClassCastException
+      throw new RuntimeException("Unexpected exception during validation", e);
+    }
+  }
+}

--- a/src/test/java/gov/nist/secauto/oscal/lib/validation/ComponentDefinitionImportTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/lib/validation/ComponentDefinitionImportTest.java
@@ -5,9 +5,9 @@
 
 package gov.nist.secauto.oscal.lib.validation;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import gov.nist.secauto.metaschema.core.model.validation.IValidationResult;
 import gov.nist.secauto.oscal.lib.OscalBindingContext;
@@ -23,8 +23,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * Test case to reproduce oscal-cli issue #192: ClassCastException when
- * validating ComponentDefinition with import-component-definitions.
+ * Test case for oscal-cli issue #192: Validates that ComponentDefinition
+ * implements IOscalInstance, preventing ClassCastException when validating
+ * component definitions with import-component-definitions.
  *
  * @see <a href=
  *      "https://github.com/metaschema-framework/oscal-cli/issues/192">Issue
@@ -34,109 +35,49 @@ class ComponentDefinitionImportTest {
   private static final Logger LOGGER = LogManager.getLogger(ComponentDefinitionImportTest.class);
 
   /**
-   * Demonstrates that ComponentDefinition does NOT implement IOscalInstance,
-   * which is the root cause of the ClassCastException in ResolveReference.
+   * Verifies that ComponentDefinition implements IOscalInstance. This is required
+   * for the resolve-reference() function to work correctly in
+   * ResolveReference.resolveReference() at line 152.
    */
   @Test
-  void testComponentDefinitionDoesNotImplementIOscalInstance() throws IOException {
+  void testComponentDefinitionImplementsIOscalInstance() throws IOException {
     OscalBindingContext bindingContext = OscalBindingContext.newInstance();
 
-    // Load the base component definition
     Path basePath = Paths.get("src/test/resources/content/issue-192/base-component-definition.json");
     ComponentDefinition componentDef = bindingContext.loadComponentDefinition(basePath);
 
-    // Verify that ComponentDefinition does NOT implement IOscalInstance
-    // This is the root cause of the bug - the cast in
-    // ResolveReference.resolveReference() line 152
-    boolean implementsIOscalInstance = componentDef instanceof IOscalInstance;
+    assertInstanceOf(IOscalInstance.class, componentDef,
+        "ComponentDefinition must implement IOscalInstance for resolve-reference() to work");
 
-    LOGGER.info("ComponentDefinition implements IOscalInstance: {}", implementsIOscalInstance);
-
-    // This assertion documents the bug: ComponentDefinition SHOULD implement
-    // IOscalInstance
-    // but currently does NOT
-    if (implementsIOscalInstance) {
-      LOGGER.info("Bug appears to be fixed - ComponentDefinition now implements IOscalInstance");
-    } else {
-      LOGGER.warn("Bug confirmed: ComponentDefinition does NOT implement IOscalInstance");
-      LOGGER.warn("This causes ClassCastException in ResolveReference.resolveReference() at line 152");
-    }
-
-    // Asserting false to document the current broken state
-    // When the bug is fixed, this test should be updated to assertTrue
-    assertTrue(!implementsIOscalInstance,
-        "This test documents the bug: ComponentDefinition should implement IOscalInstance but doesn't");
+    LOGGER.info("ComponentDefinition correctly implements IOscalInstance");
   }
 
   /**
-   * Reproduces the ClassCastException from oscal-cli issue #192.
+   * Verifies that validating a ComponentDefinition with
+   * import-component-definitions does not throw a ClassCastException.
    *
-   * When validating a ComponentDefinition with import-component-definitions that
-   * uses a fragment reference (href="#uuid"), the constraint evaluation calls
-   * resolve-reference() which attempts to cast the root ComponentDefinition to
-   * IOscalInstance, causing:
-   *
-   * ClassCastException: class
+   * Previously (issue #192), this would fail with: ClassCastException: class
    * gov.nist.secauto.oscal.lib.model.ComponentDefinition cannot be cast to class
    * gov.nist.secauto.oscal.lib.model.IOscalInstance
    */
   @Test
-  void testValidateComponentDefinitionWithImportCausesClassCastException() {
+  void testValidateComponentDefinitionWithImport() {
     OscalBindingContext bindingContext = OscalBindingContext.newInstance();
 
     Path componentDefPath = Paths.get("src/test/resources/content/issue-192/component-definition-with-import.json");
 
-    try {
-      // This validation should trigger the constraint that uses resolve-reference()
-      // The constraint is defined in ComponentDefinition's @ValueConstraints
-      // annotation:
-      // "import-component-definition !
-      // recurse-depth('doc(resolve-uri(Q{...}resolve-reference(@href)))/component-definition')"
-      IValidationResult validationResult = bindingContext.validateWithConstraints(
-          componentDefPath.toUri(),
-          null);
+    // Validation should complete without ClassCastException
+    IValidationResult validationResult = assertDoesNotThrow(
+        () -> bindingContext.validateWithConstraints(componentDefPath.toUri(), null),
+        "Validation should not throw ClassCastException");
 
-      // If we get here without exception, check if validation passed or had expected
-      // findings
-      if (validationResult.isPassing()) {
-        LOGGER.info("Validation passed - bug may be fixed or constraint not triggered");
-      } else {
-        LOGGER.info("Validation completed with findings (no ClassCastException)");
-      }
+    assertNotNull(validationResult, "Validation result should not be null");
 
-    } catch (ClassCastException e) {
-      // This is the expected behavior when the bug is present
-      LOGGER.error("Bug reproduced: ClassCastException during validation", e);
-
-      // Verify it's the specific cast error from ResolveReference
-      assertTrue(e.getMessage().contains("ComponentDefinition")
-          && e.getMessage().contains("IOscalInstance"),
-          "Expected ClassCastException from ComponentDefinition to IOscalInstance cast");
-
-      // Fail the test to indicate the bug exists
-      fail("Issue #192 reproduced: " + e.getMessage());
-
-    } catch (Exception e) {
-      // Log any other exception for debugging
-      LOGGER.error("Unexpected exception during validation", e);
-
-      // Check if the root cause is the ClassCastException
-      Throwable cause = e;
-      while (cause != null) {
-        if (cause instanceof ClassCastException) {
-          ClassCastException cce = (ClassCastException) cause;
-          if (cce.getMessage() != null
-              && cce.getMessage().contains("ComponentDefinition")
-              && cce.getMessage().contains("IOscalInstance")) {
-            LOGGER.error("Bug reproduced (wrapped): ClassCastException found in cause chain", cce);
-            fail("Issue #192 reproduced (wrapped exception): " + cce.getMessage());
-          }
-        }
-        cause = cause.getCause();
-      }
-
-      // Re-throw if it's not the expected ClassCastException
-      throw new RuntimeException("Unexpected exception during validation", e);
+    if (validationResult.isPassing()) {
+      LOGGER.info("Validation passed successfully");
+    } else {
+      LOGGER.info("Validation completed with {} findings (no ClassCastException)",
+          validationResult.getFindings().size());
     }
   }
 }

--- a/src/test/resources/content/issue-192/base-component-definition.json
+++ b/src/test/resources/content/issue-192/base-component-definition.json
@@ -1,0 +1,19 @@
+{
+  "component-definition": {
+    "uuid": "a0000000-0000-0000-0000-000000000001",
+    "metadata": {
+      "title": "Base Component Definition for Import Testing",
+      "last-modified": "2024-01-01T00:00:00Z",
+      "version": "1.0.0",
+      "oscal-version": "1.1.2"
+    },
+    "components": [
+      {
+        "uuid": "c0000000-0000-0000-0000-000000000001",
+        "type": "software",
+        "title": "Test Software Component",
+        "description": "A test software component for import testing."
+      }
+    ]
+  }
+}

--- a/src/test/resources/content/issue-192/component-definition-with-import.json
+++ b/src/test/resources/content/issue-192/component-definition-with-import.json
@@ -1,0 +1,29 @@
+{
+  "component-definition": {
+    "uuid": "b0000000-0000-0000-0000-000000000001",
+    "metadata": {
+      "title": "Component Definition with Import",
+      "last-modified": "2024-01-01T00:00:00Z",
+      "version": "1.0.0",
+      "oscal-version": "1.1.2"
+    },
+    "import-component-definitions": [
+      {
+        "href": "#d0000000-0000-0000-0000-000000000001"
+      }
+    ],
+    "back-matter": {
+      "resources": [
+        {
+          "uuid": "d0000000-0000-0000-0000-000000000001",
+          "title": "Imported Component Definition Resource",
+          "rlinks": [
+            {
+              "href": "base-component-definition.json"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add metaschema bindings for `component-definition` and `mapping-collection` to extend `AbstractOscalInstance`, which implements `IOscalInstance`
- Add test case to verify the fix for validating ComponentDefinition documents with `import-component-definitions`

## Problem

When validating a ComponentDefinition with `import-component-definitions` that uses fragment references (`href="#uuid"`), the constraint evaluation calls `resolve-reference()` which attempts to cast the root `ComponentDefinition` to `IOscalInstance`. This fails because `ComponentDefinition` (and `MappingCollection`) did not implement `IOscalInstance`.

The error was:
```
ClassCastException: class gov.nist.secauto.oscal.lib.model.ComponentDefinition 
cannot be cast to class gov.nist.secauto.oscal.lib.model.IOscalInstance
```

## Solution

Add bindings in `oscal-metaschema-bindings.xml` for:
- `component-definition` → extends `AbstractOscalInstance`
- `mapping-collection` → extends `AbstractOscalInstance`

This matches the pattern used by other OSCAL root types (Profile, SystemSecurityPlan, AssessmentPlan, etc.).

## Test plan

- [x] `testComponentDefinitionImplementsIOscalInstance` - Verifies ComponentDefinition implements IOscalInstance
- [x] `testValidateComponentDefinitionWithImport` - Verifies validation completes without ClassCastException
- [x] Full test suite passes (49 tests, 0 failures)

Fixes: metaschema-framework/oscal-cli#192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metaschema binding support for component definitions and mapping collections, extending OSCAL model support.

* **Tests**
  * Added tests verifying component-definition import behavior and validation to prevent class/validation errors.
  * Added test fixtures supporting component-definition import and validation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->