### PR TITLE
fix: exclude submodules from Trivy and CodeQL security scans

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "CodeQL config"
+
+# Exclude submodules from analysis - they have their own security scanning in their upstream repos
+paths-ignore:
+  - oscal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,7 @@ jobs:
       uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7
       with:
         languages: java
+        config-file: .github/codeql-config.yml
     # -------------------------
     # Maven Build
     # -------------------------
@@ -189,6 +190,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results.sarif'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
+        # Exclude submodule (has its own security scanning in upstream repo)
+        skip-dirs: 'oscal'
     - name: Trivy Summary
       if: ${{ !inputs.skip_code_scans }}
       run: |


### PR DESCRIPTION
## Summary

- Exclude the `oscal` submodule from Trivy and CodeQL security scans
- Submodules are outside the administrative domain of this repository and have their own security scanning in their upstream repos
- Scanning them here creates noise and duplicates alerts that should be addressed upstream

## Changes

- Added `skip-dirs: 'oscal'` to Trivy action configuration
- Created `.github/codeql-config.yml` with `paths-ignore` for the oscal submodule
- Updated CodeQL init action to reference the config file

## Test plan

- [ ] Verify Trivy scan no longer reports vulnerabilities from `oscal/` paths
- [ ] Verify CodeQL scan no longer analyzes code in `oscal/` paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL and Trivy scanning configuration for GitHub workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->