### PR TITLE
chore: update to metaschema-java 3.0.0-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ velocity.log*
 # Claude
 CLAUDE.local.md
 .claude/settings.local.json
+tmpclaude-*-cwd
 
 # Git worktrees
 .worktrees/

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 		<project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<dependency.metaschema-framework.version>3.0.0.M2</dependency.metaschema-framework.version>
+		<dependency.metaschema-framework.version>3.0.0-SNAPSHOT</dependency.metaschema-framework.version>
 
 		<dependency.commons-lang3.version>3.20.0</dependency.commons-lang3.version>
 		<dependency.jmock-junit5.version>2.13.1</dependency.jmock-junit5.version>


### PR DESCRIPTION
## Summary

- Update metaschema-framework dependency from `3.0.0.M2` to `3.0.0-SNAPSHOT` for ongoing development
- Add `tmpclaude-*-cwd` pattern to `.gitignore` to exclude Claude temporary working directory files

## Test plan

- [ ] Verify build compiles with the updated SNAPSHOT dependency
- [x] Confirm no unintended files are tracked by git

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core framework dependencies for improved stability and compatibility
  * Refined development environment configuration to optimize build processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->