### PR TITLE
build: exclude maven2 artifact repo checkout from Trivy scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,8 +211,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results.sarif'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
-        # Exclude submodule (has its own security scanning in upstream repo)
-        skip-dirs: 'oscal'
+        # Exclude submodule and maven2 artifact repo checkout (have their own security scanning)
+        skip-dirs: 'oscal,maven2'
     - name: Trivy Summary
       if: ${{ !inputs.skip_code_scans }}
       run: |


### PR DESCRIPTION
## Summary

- Add `maven2` to Trivy's `skip-dirs` alongside the existing `oscal` exclusion. The `maven2/` directory is a transient checkout of the artifact repository used only during deployment — its dependencies (e.g., `fast-xml-parser` in the pruner tool) are not part of liboscal-java and should be scanned in the maven2 repository instead.
- Resolves the high-severity CVE-2026-25128 finding that was failing the build.

## Test plan

- [ ] Verify CI build passes without Trivy flagging maven2 dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration in CI/CD pipeline to adjust directory exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->