### PR TITLE
Update metaschema-java to 3.0.0.M3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 		<project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<dependency.metaschema-framework.version>3.0.0-SNAPSHOT</dependency.metaschema-framework.version>
+		<dependency.metaschema-framework.version>3.0.0.M3</dependency.metaschema-framework.version>
 
 		<dependency.commons-lang3.version>3.20.0</dependency.commons-lang3.version>
 		<dependency.jmock-junit5.version>2.13.1</dependency.jmock-junit5.version>


### PR DESCRIPTION
## Summary
- Update `dependency.metaschema-framework.version` from `3.0.0-SNAPSHOT` to `3.0.0.M3` release

## Test plan
- [x] Full build passes (`mvn install`)
- [x] All tests pass (49 run, 0 failures, 0 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metaschema-framework dependency to version 3.0.0.M3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->