### PR TITLE
build: update OSCAL submodule to v1.2.1

### DIFF
--- a/src/main/metaschema-bindings/oscal-metaschema-bindings.xml
+++ b/src/main/metaschema-bindings/oscal-metaschema-bindings.xml
@@ -56,6 +56,17 @@
 				<extend-base-class>dev.metaschema.oscal.lib.model.control.AbstractPart</extend-base-class>
 			</java>
 		</define-assembly-binding>
+		<define-assembly-binding name="select-control-by-id">
+			<java>
+				<use-class-name>ProfileSelectControlById</use-class-name>
+				<extend-base-class>dev.metaschema.oscal.lib.model.control.profile.AbstractProfileSelectControlById</extend-base-class>
+			</java>
+		</define-assembly-binding>
+		<define-assembly-binding name="matching">
+			<java>
+				<use-class-name>ProfileMatching</use-class-name>
+			</java>
+		</define-assembly-binding>
 	</metaschema-binding>
 	<metaschema-binding
 		href="../../../oscal/src/metaschema/oscal_catalog_metaschema.xml">
@@ -94,20 +105,9 @@
 				<use-class-name>ProfileGroup</use-class-name>
 			</java>
 		</define-assembly-binding>
-		<define-assembly-binding name="select-control-by-id">
-			<java>
-				<use-class-name>ProfileSelectControlById</use-class-name>
-				<extend-base-class>dev.metaschema.oscal.lib.model.control.profile.AbstractProfileSelectControlById</extend-base-class>
-			</java>
-		</define-assembly-binding>
 		<define-assembly-binding name="set-parameter">
 			<java>
 				<use-class-name>ProfileSetParameter</use-class-name>
-			</java>
-		</define-assembly-binding>
-		<define-assembly-binding name="matching">
-			<java>
-				<use-class-name>ProfileMatching</use-class-name>
 			</java>
 		</define-assembly-binding>
 	</metaschema-binding>


### PR DESCRIPTION
## Summary

- Update OSCAL submodule from v1.2.0 to v1.2.1 (includes JSON schema corrections, assembly definition fixes, and constraint corrections)
- Move `select-control-by-id` and `matching` binding configurations from the profile metaschema section to the control-common metaschema section, matching OSCAL v1.2.1's consolidation of these definitions into `oscal_control-common_metaschema.xml`
- Update the FedRAMP profile validation test URL to the new `OSCAL-Foundation/fedramp-automation` repository (rev5 MODERATE baseline), since `GSA/fedramp-automation` is no longer publicly accessible

## Test plan

- [x] `mvn install -PCI -Prelease` passes
- [x] All 49 unit tests pass (1 pre-existing `@Disabled` remains disabled)
- [x] `OscalValidationTest.testValidateOscalProfileXml` now passes against the new FedRAMP repository URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OSCAL subproject dependency to latest version
  * Reorganized internal configuration bindings for improved structure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->