### PR TITLE
build: fix CI infrastructure (Trivy action bump + FedRAMP test URL)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
     # -------------------------
     - name: Run Trivy security scanner
       if: ${{ !inputs.skip_code_scans }}
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         scan-type: 'fs'
         scan-ref: '.'

--- a/src/test/java/dev/metaschema/oscal/lib/validation/OscalValidationTest.java
+++ b/src/test/java/dev/metaschema/oscal/lib/validation/OscalValidationTest.java
@@ -80,7 +80,7 @@ class OscalValidationTest {
 
     IValidationResult validationResult = bindingContext.validate(
         new URI(
-            "https://raw.githubusercontent.com/GSA/fedramp-automation/refs/heads/develop/src/validations/constraints/content/fedramp-tailoring-profile.xml"),
+            "https://raw.githubusercontent.com/OSCAL-Foundation/fedramp-automation/refs/heads/master/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml"),
         Format.XML,
         new ValidationProvider(module),
         null);

--- a/src/test/java/dev/metaschema/oscal/lib/validation/OscalValidationTest.java
+++ b/src/test/java/dev/metaschema/oscal/lib/validation/OscalValidationTest.java
@@ -80,7 +80,7 @@ class OscalValidationTest {
 
     IValidationResult validationResult = bindingContext.validate(
         new URI(
-            "https://raw.githubusercontent.com/OSCAL-Foundation/fedramp-automation/refs/heads/master/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml"),
+            "https://raw.githubusercontent.com/OSCAL-Foundation/fedramp-automation/c784140bc6d1ac9fa159aabc0e8a29e9aa2c63a9/src/content/rev5/baselines/xml/FedRAMP_rev5_MODERATE-baseline_profile.xml"),
         Format.XML,
         new ValidationProvider(module),
         null);


### PR DESCRIPTION
## Summary

Two CI infrastructure fixes that together unblock all PR builds:

1. **Bump `aquasecurity/trivy-action` from v0.33.1 to v0.35.0** — The v0.33.1 pinned version's Trivy install step has been failing in CI since 2026-02-10 (exit code 1 immediately after fetching the Trivy binary), blocking every PR regardless of code content.
2. **Update FedRAMP profile URL in `OscalValidationTest.testValidateOscalProfileXml`** — The `GSA/fedramp-automation` repository is no longer publicly accessible, causing the test to fail with `FileNotFound` on every CI run. Point it at the equivalent profile in `OSCAL-Foundation/fedramp-automation` (rev5 MODERATE baseline), the current home for FedRAMP automation work.

## Test plan

- [ ] CI "Build and Test Code" step completes successfully (FedRAMP test passes)
- [ ] CI "Run Trivy security scanner" step completes successfully
- [ ] SARIF results file is generated and uploaded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI security scanning configuration to use a different pinned version of the scanner, ensuring alignment with a newer scanner release.

* **Tests**
  * Adjusted a validation test to target an updated OSCAL FedRAMP profile, keeping the test's assertions and validation flow unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->