### PR TITLE
fix: handle unevaluable let and target expressions in allowed-values visitor

### DIFF
--- a/src/main/java/dev/metaschema/oscal/lib/model/util/AllowedValueCollectingNodeItemVisitor.java
+++ b/src/main/java/dev/metaschema/oscal/lib/model/util/AllowedValueCollectingNodeItemVisitor.java
@@ -5,6 +5,9 @@
 
 package dev.metaschema.oscal.lib.model.util;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -12,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 import dev.metaschema.core.metapath.DynamicContext;
+import dev.metaschema.core.metapath.MetapathException;
 import dev.metaschema.core.metapath.StaticContext;
 import dev.metaschema.core.metapath.item.ISequence;
 import dev.metaschema.core.metapath.item.node.AbstractRecursionPreventingNodeItemVisitor;
@@ -29,6 +33,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class AllowedValueCollectingNodeItemVisitor
     extends AbstractRecursionPreventingNodeItemVisitor<DynamicContext, Void> {
+  private static final Logger LOGGER = LogManager.getLogger(AllowedValueCollectingNodeItemVisitor.class);
 
   private final Map<IDefinitionNodeItem<?, ?>, NodeItemRecord> nodeItemAnalysis = new LinkedHashMap<>();
 
@@ -56,11 +61,18 @@ public class AllowedValueCollectingNodeItemVisitor
       @NonNull DynamicContext context) {
     itemLocation.getDefinition().getAllowedValuesConstraints().stream()
         .forEachOrdered(allowedValues -> {
-          ISequence<?> result = allowedValues.getTarget().evaluate(itemLocation, context);
-          result.stream().forEachOrdered(target -> {
-            assert target != null;
-            handleAllowedValues(allowedValues, itemLocation, (IDefinitionNodeItem<?, ?>) target);
-          });
+          try {
+            ISequence<?> result = allowedValues.getTarget().evaluate(itemLocation, context);
+            result.stream().forEachOrdered(target -> {
+              assert target != null;
+              handleAllowedValues(allowedValues, itemLocation, (IDefinitionNodeItem<?, ?>) target);
+            });
+          } catch (MetapathException ex) {
+            LOGGER.atWarn().log(
+                "Skipping allowed-values constraint target '{}' at '{}' because it cannot be evaluated"
+                    + " against the module definition: {}",
+                allowedValues.getTarget().getPath(), itemLocation.getMetapath(), ex.getLocalizedMessage());
+          }
         });
   }
 
@@ -106,9 +118,19 @@ public class AllowedValueCollectingNodeItemVisitor
     assert context != null;
     DynamicContext subContext = context;
     for (ILet let : item.getDefinition().getLetExpressions().values()) {
-      ISequence<?> result = let.getValueExpression().evaluate(item,
-          subContext).reusable();
-      subContext = subContext.bindVariableValue(let.getName(), result);
+      try {
+        ISequence<?> result = let.getValueExpression().evaluate(item,
+            subContext).reusable();
+        subContext = subContext.bindVariableValue(let.getName(), result);
+      } catch (MetapathException ex) {
+        // Let expressions may reference runtime-only data (e.g., resolving an href)
+        // that is not available when walking the module definition. Skip binding the
+        // variable in that case; dependent expressions will be skipped downstream.
+        LOGGER.atWarn().log(
+            "Skipping let expression '${}' at '{}' because it cannot be evaluated against"
+                + " the module definition: {}",
+            let.getName(), item.getMetapath(), ex.getLocalizedMessage());
+      }
     }
     return subContext;
   }

--- a/src/test/java/dev/metaschema/oscal/lib/model/util/AllowedValueCollectingNodeItemVisitorTest.java
+++ b/src/test/java/dev/metaschema/oscal/lib/model/util/AllowedValueCollectingNodeItemVisitorTest.java
@@ -5,6 +5,7 @@
 
 package dev.metaschema.oscal.lib.model.util;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -20,9 +21,12 @@ import dev.metaschema.core.model.MetaschemaException;
 import dev.metaschema.core.model.constraint.IConstraintSet;
 import dev.metaschema.core.util.ObjectUtils;
 import dev.metaschema.databind.IBindingContext;
+import dev.metaschema.databind.model.IBoundModule;
 import dev.metaschema.databind.model.metaschema.BindingConstraintLoader;
 import dev.metaschema.databind.model.metaschema.IBindingMetaschemaModule;
 import dev.metaschema.databind.model.metaschema.IBindingModuleLoader;
+import dev.metaschema.oscal.lib.OscalBindingContext;
+import dev.metaschema.oscal.lib.model.OscalCompleteModule;
 import dev.metaschema.oscal.lib.model.util.AllowedValueCollectingNodeItemVisitor.NodeItemRecord;
 
 class AllowedValueCollectingNodeItemVisitorTest {
@@ -74,5 +78,13 @@ class AllowedValueCollectingNodeItemVisitorTest {
     walker.visit(module);
     Collection<NodeItemRecord> allowedValuesByTarget = ObjectUtils.notNull(walker.getAllowedValueLocations());
     assertEquals(1, allowedValuesByTarget.size());
+  }
+
+  @Test
+  void testVisitOscalCompleteModuleHandlesUnevaluableLets() throws MetaschemaException {
+    IBoundModule module = OscalBindingContext.instance().registerModule(OscalCompleteModule.class);
+
+    AllowedValueCollectingNodeItemVisitor walker = new AllowedValueCollectingNodeItemVisitor();
+    assertDoesNotThrow(() -> walker.visit(module));
   }
 }


### PR DESCRIPTION
## Summary
- `AllowedValueCollectingNodeItemVisitor` walks the module definition, not instance data. OSCAL constraint let expressions such as `import-component-definition ! recurse-depth('…resolve-reference(@href)…')` atomize flag nodes that have no typed value at the definition level, raising `InvalidTypeFunctionException` (FOTY0013) and aborting the walk. This prevents `oscal-cli list-allowed-values` from running.
- Catch `MetapathException` around let-variable binding and allowed-values target evaluation, log a warning, and continue. Expressions that reference an unbound let variable are skipped downstream in the same way.
- Companion fix in metaschema-java (where the visitor now also lives after PR #666): metaschema-framework/metaschema-java#(pending).

## Test plan
- [x] New unit test `testVisitOscalCompleteModuleHandlesUnevaluableLets` — asserts `walker.visit(OscalCompleteModule)` does not throw
- [x] Confirmed RED reproduces the exact CLI error, GREEN after the fix
- [x] Full visitor test suite passes (3 tests); full liboscal-java test suite passes modulo the pre-existing FedRAMP URL 404 test
- [x] End-to-end: rebuilt `oscal-cli` against the snapshot, `oscal-cli list-allowed-values` now emits skip warnings and produces YAML output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when processing allowed values and variable definitions. The system now gracefully handles failed expression evaluations with detailed error logging.

* **Tests**
  * Added test coverage for handling unevaluable expressions in variable definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->