### PR TITLE
fix: validate profile imports against their own catalogs (oscal-cli#250)

### DIFF
--- a/src/main/metaschema-constraints/oscal-external-constraints.xml
+++ b/src/main/metaschema-constraints/oscal-external-constraints.xml
@@ -118,14 +118,13 @@
 		
         <constraints>
             <let var="resolved-profile-import" expression=".[@href] ! resolve-profile(doc(resolve-uri(Q{http://csrc.nist.gov/ns/oscal/1.0}resolve-reference(@href))))/catalog"/>
-			<index id="oscal-profile-import-index-control-id" name="profile-import-index-control-id" target="$resolved-profile-import//control">
-            	<formal-name>In-Scope Control Identifiers</formal-name>
-            	<description>An index of control identifiers that are in-scope for selection in the profile import.</description>
-                <key-field target="@id"/>
-            </index>
-            <index-has-key id="oscal-profile-import-has-key-include-exclude-control-id" name="profile-import-index-control-id" target="(include-controls|exclude-controls)/with-id">
-                <key-field target="."/>
-            </index-has-key>
+            <expect id="oscal-profile-import-include-exclude-control-id-in-imported-catalog"
+                    target="(include-controls|exclude-controls)/with-id"
+                    test="let $id := . return exists($resolved-profile-import//control[@id = $id])">
+                <formal-name>In-Scope Control Identifier</formal-name>
+                <description>Each referenced control identifier must match a control in the catalog resolved by the surrounding profile import.</description>
+                <message>Control identifier '{ . }' was not found in the imported catalog.</message>
+            </expect>
         </constraints>
     </context>
     <context>

--- a/src/test/java/dev/metaschema/oscal/lib/validation/OscalValidationTest.java
+++ b/src/test/java/dev/metaschema/oscal/lib/validation/OscalValidationTest.java
@@ -112,6 +112,27 @@ class OscalValidationTest {
     assertFalse(validationResult.isPassing());
   }
 
+  @Test
+  void testValidateProfileWithMultipleImports()
+      throws MetaschemaException, IOException, URISyntaxException, ConstraintValidationException {
+    // Regression test for oscal-cli#250: a profile that imports two catalogs
+    // should validate every with-id against the catalog referenced by the
+    // same import, not against an index built from the first import only.
+    IBindingContext bindingContext = OscalBindingContext.newInstance();
+
+    IValidationResult validationResult = bindingContext.validateWithConstraints(
+        Paths.get("src/test/resources/content/issue-250/test-profile.json").toUri(),
+        null);
+
+    if (validationResult.isPassing()) {
+      LOGGER.info("The resource is valid.");
+    } else {
+      LOGGER.info("Validation identified the following issues:");
+      new LoggingValidationHandler().handleResults(validationResult);
+    }
+    assertTrue(validationResult.isPassing());
+  }
+
   private static final class ValidationProvider implements ISchemaValidationProvider {
     @NonNull
     private final IModule module;

--- a/src/test/java/dev/metaschema/oscal/lib/validation/OscalValidationTest.java
+++ b/src/test/java/dev/metaschema/oscal/lib/validation/OscalValidationTest.java
@@ -118,10 +118,25 @@ class OscalValidationTest {
     // Regression test for oscal-cli#250: a profile that imports two catalogs
     // should validate every with-id against the catalog referenced by the
     // same import, not against an index built from the first import only.
+    assertMultiImportProfileValidates("src/test/resources/content/issue-250/test-profile.json");
+  }
+
+  @Test
+  void testValidateProfileWithMultipleImportsReversed()
+      throws MetaschemaException, IOException, URISyntaxException, ConstraintValidationException {
+    // Companion regression for oscal-cli#250: the original bug report noted
+    // that reversing the import order moved the errors. This test validates
+    // the same two catalogs with their import order swapped to guard against
+    // any future reintroduction of import-order sensitivity.
+    assertMultiImportProfileValidates("src/test/resources/content/issue-250/test-profile-reversed.json");
+  }
+
+  private void assertMultiImportProfileValidates(@NonNull String profilePath)
+      throws MetaschemaException, IOException, ConstraintValidationException {
     IBindingContext bindingContext = OscalBindingContext.newInstance();
 
     IValidationResult validationResult = bindingContext.validateWithConstraints(
-        Paths.get("src/test/resources/content/issue-250/test-profile.json").toUri(),
+        Paths.get(profilePath).toUri(),
         null);
 
     if (validationResult.isPassing()) {

--- a/src/test/resources/content/issue-250/test-catalog-ac-1.json
+++ b/src/test/resources/content/issue-250/test-catalog-ac-1.json
@@ -1,0 +1,23 @@
+{
+  "catalog": {
+    "uuid": "5f6606a2-5d1f-4df2-8d5e-4c0e7b57bea6",
+    "metadata": {
+      "title": "Minimal AC Family Catalog",
+      "last-modified": "2026-02-25T02:49:04Z",
+      "version": "1.0.0",
+      "oscal-version": "1.2.1"
+    },
+    "controls": [
+      {
+        "id": "ac-1",
+        "title": "Access Control Policy and Procedures",
+        "parts": [
+          {
+            "name": "statement",
+            "prose": "Minimal AC-1 statement used only to validate profile imports."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/content/issue-250/test-catalog.json
+++ b/src/test/resources/content/issue-250/test-catalog.json
@@ -1,0 +1,23 @@
+{
+  "catalog": {
+    "uuid": "a7167eec-1ab2-4ec3-9921-5680981be857",
+    "metadata": {
+      "title": "Test Catalog",
+      "last-modified": "2026-02-25T02:49:04Z",
+      "version": "1.0.0",
+      "oscal-version": "1.2.1"
+    },
+    "controls": [
+      {
+        "id": "test-01",
+        "title": "TEST CONTROL",
+        "parts": [
+          {
+            "name": "statement",
+            "prose": "Test content"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/content/issue-250/test-profile-reversed.json
+++ b/src/test/resources/content/issue-250/test-profile-reversed.json
@@ -1,29 +1,29 @@
 {
   "profile": {
-    "uuid": "e285521b-890c-4b8e-b0c3-e72fac21a51e",
+    "uuid": "13a94063-d30b-4fc8-bf3b-b75bf9da0b72",
     "metadata": {
-      "title": "Test Profile",
+      "title": "Test Profile (Reversed Imports)",
       "last-modified": "2026-03-23T00:00:00Z",
       "version": "1.0.0",
       "oscal-version": "1.2.1"
     },
     "imports": [
       {
-        "href": "test-catalog-ac-1.json",
-        "include-controls": [
-          {
-            "with-ids": [
-              "ac-1"
-            ]
-          }
-        ]
-      },
-      {
         "href": "test-catalog.json",
         "include-controls": [
           {
             "with-ids": [
               "test-01"
+            ]
+          }
+        ]
+      },
+      {
+        "href": "test-catalog-ac-1.json",
+        "include-controls": [
+          {
+            "with-ids": [
+              "ac-1"
             ]
           }
         ]

--- a/src/test/resources/content/issue-250/test-profile.json
+++ b/src/test/resources/content/issue-250/test-profile.json
@@ -1,0 +1,36 @@
+{
+  "profile": {
+    "uuid": "e285521b-890c-4b8e-b0c3-e72fac21a51e",
+    "metadata": {
+      "title": "Test Profile",
+      "last-modified": "2026-03-23T00:00:00Z",
+      "version": "1.0.0",
+      "oscal-version": "1.2.1"
+    },
+    "imports": [
+      {
+        "href": "../../../../../target/download/content/NIST_SP-800-53_rev5_catalog.json",
+        "include-controls": [
+          {
+            "with-ids": [
+              "ac-1"
+            ]
+          }
+        ]
+      },
+      {
+        "href": "test-catalog.json",
+        "include-controls": [
+          {
+            "with-ids": [
+              "test-01"
+            ]
+          }
+        ]
+      }
+    ],
+    "merge": {
+      "as-is": true
+    }
+  }
+}


### PR DESCRIPTION
Closes metaschema-framework/oscal-cli#250

## Summary

Fixes [metaschema-framework/oscal-cli#250](https://github.com/metaschema-framework/oscal-cli/issues/250): when a profile imports two or more catalogs and uses `with-ids` rather than `include-all`, validation incorrectly reports control identifiers on the second (and later) imports as missing.

## Root cause

In `src/main/metaschema-constraints/oscal-external-constraints.xml`, the `/profile/import` context defined:

```xml
<index id="oscal-profile-import-index-control-id"
       name="profile-import-index-control-id"
       target="$resolved-profile-import//control">
    <key-field target="@id"/>
</index>
<index-has-key id="oscal-profile-import-has-key-include-exclude-control-id"
               name="profile-import-index-control-id"
               target="(include-controls|exclude-controls)/with-id">
    <key-field target="."/>
</index-has-key>
```

Metaschema index names are **document-global**. With two imports, both instances of the constraint try to build an index with the same name — the validator emits a "Duplicate index" finding on the second import, the second index is discarded, and subsequent `with-id` lookups resolve against the first import's catalog only. Every id from the second import's catalog is then reported missing.

## Fix

Replace the index/index-has-key pair with an inline `expect` that uses the per-import `$resolved-profile-import` `let` binding to perform the lookup directly:

```xml
<expect id="oscal-profile-import-include-exclude-control-id-in-imported-catalog"
        target="(include-controls|exclude-controls)/with-id"
        test="let $id := . return exists($resolved-profile-import//control[@id = $id])">
    ...
</expect>
```

Each import evaluates its `test` against the catalog resolved for the same import, with no shared global state.

## Test plan

- [x] New regression test `OscalValidationTest#testValidateProfileWithMultipleImports` — builds a two-import profile (one import uses the build-downloaded NIST 800-53 rev5 catalog at `target/download/content/NIST_SP-800-53_rev5_catalog.json`, the other a minimal local catalog with a single `test-01` control). Fails on pre-fix, passes on post-fix.
- [x] Existing `OscalValidationTest#testValidateProfileWithMissingControls` still correctly reports invalid control ids — the new `expect` replaces the missing-control detection end-to-end.
- [x] `mvn test` — 47 tests run, 0 failures, 0 errors, 3 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation for profiles importing multiple catalogs now checks that referenced control IDs exist in the imported catalogs and reports a clear error when an ID is missing.

* **Tests**
  * Added regression tests covering multi-catalog imports (including reversed import order) and new test fixtures to ensure consistent validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
