### PR TITLE
build(deps): bump metaschema-framework from 3.0.0.M3 to 3.0.0.M4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 		<project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<dependency.metaschema-framework.version>3.0.0.M3</dependency.metaschema-framework.version>
+		<dependency.metaschema-framework.version>3.0.0.M4</dependency.metaschema-framework.version>
 
 		<dependency.commons-lang3.version>3.20.0</dependency.commons-lang3.version>
 		<dependency.jmock-junit5.version>2.13.1</dependency.jmock-junit5.version>


### PR DESCRIPTION
## Summary
- Bumps `dependency.metaschema-framework.version` from `3.0.0.M3` to `3.0.0.M4`
- Affects `metaschema-core`, `metaschema-databind`, `metaschema-schema-generator`, and the `metaschema-maven-plugin` (all share the same version property)

## Test plan
- [x] `mvn install -DskipTests` succeeds (codegen + schema generation run against M4)
- [x] `mvn test` — all 48 tests pass, 0 failures, 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metaschema-framework and related dependencies from version 3.0.0.M3 to 3.0.0.M4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/metaschema-framework/liboscal-java/pull/287)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->